### PR TITLE
In stress testing on a raspberry pi, I found that some ACC and ACDC b…

### DIFF
--- a/include/Metadata.h
+++ b/include/Metadata.h
@@ -17,7 +17,7 @@ public:
 	Metadata(vector<unsigned short> acdcBuffer); //if a buffer exists already to parse
 	~Metadata();
 
-	void parseBuffer(vector<unsigned short> acdcBuffer); 
+	bool parseBuffer(vector<unsigned short> acdcBuffer); //returns success or fail 1/0
 	vector<int> getMaskedChannels(); //returns a vector format of masked channels
 	void standardPrint(); //lite print
 	void printAllMetadata(); //full raw print. 

--- a/lib/ACC.cpp
+++ b/lib/ACC.cpp
@@ -224,6 +224,18 @@ vector<int> ACC::whichAcdcsConnected(bool pullNew)
 		if((alignment_packet & (1 << i)))
 		{
 			//the i'th board is connected
+
+			//protection against a NASTY error I saw
+			//due to a bad ACC buffer. We will need to investigate
+			//but for now I am protecting against seg faults. 
+			if(i > 3)
+			{
+				//return with no connected boards
+				connectedBoards.clear();
+				alignedAcdcIndices = connectedBoards;
+				return connectedBoards;
+			}
+
 			connectedBoards.push_back(i);
 		}
 	}


### PR DESCRIPTION
…uffers were corrupt with 4 boards connected. I added protections to Metadata and ACC such that if this happens, no random access data structures are accessed badly (i.e. the program runs and closes without seg-faulting)